### PR TITLE
FEAT: PDF generation

### DIFF
--- a/create_pdf.sh
+++ b/create_pdf.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+echo "Generating PDF document from markdown"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR" || exit
+
+cp -rf "$SCRIPT_DIR/spec-publisher/pandoc/img" "$SCRIPT_DIR/doc/pdf/"
+cp -rf "$SCRIPT_DIR/spec-publisher/res/md/figs" "$SCRIPT_DIR/doc/pdf/"
+cp -rf "$SCRIPT_DIR/specification/figs" "$SCRIPT_DIR/doc/pdf/"
+cd doc/pdf || exit
+
+echo " - PANDOC: Generating Preface from markdown"
+pandoc  --from gfm \
+        --to latex \
+        --metadata-file "$SCRIPT_DIR/spec-publisher/pandoc/metadata.yaml" \
+        "./preface.md" \
+        -o "./preface.tex"
+sed -i 's%section{%section*{%' ./preface.tex
+
+echo " - PANDOC: Generating Postface from markdown"
+pandoc  --from markdown \
+        --to latex \
+        --metadata-file "$SCRIPT_DIR/spec-publisher/pandoc/metadata.yaml" \
+        "$SCRIPT_DIR/specification/postface/postface.md" \
+        -o "./postface.tex"
+sed -i 's%section{%section*{%' ./postface.tex
+
+command -v markdown-pp >/dev/null 2>&1 || {
+  tmpdir=$(dirname "$(mktemp -u)")
+  # shellcheck source=/tmp/.venv-markdown/bin/activate
+  source "$tmpdir/.venv-markdown/bin/activate"
+}
+
+echo " - MARKDOWN-PP: Preparing PDF markdown"
+markdown-pp PDF.md -o eark-3dpm-pdf.md -e tableofcontents
+echo " - MARKDOWN-PP: Preparing PDF markdown"
+sed -i 's%@csip:CONTENTINFORMATIONTYPE='\''cits3dpm_v1_0'\''%@csip:CONTENTINFORMATIONTYPE='\''cits3dpm\\_v1\\_0'\''%' ./eark-3dpm-pdf.md
+
+
+if [ -d "$SCRIPT_DIR/site/pdf" ]
+then
+  echo " - Removing old site PDF directory"
+  rm -rf "$SCRIPT_DIR/site/pdf"
+fi
+mkdir "$SCRIPT_DIR/site/pdf"
+
+echo " - PANDOC: Generating PDF document from markdown and Tex sources"
+pandoc  --from markdown \
+        --template "$SCRIPT_DIR/spec-publisher/pandoc/templates/eisvogel.latex" \
+        --listings \
+        --table-of-contents \
+        --metadata-file "$SCRIPT_DIR/spec-publisher/pandoc/metadata.yaml" \
+        --include-before-body "./preface.tex" \
+        --include-after-body "./postface.tex" \
+        --number-sections \
+        eark-3dpm-pdf.md \
+        -o "$SCRIPT_DIR/site/pdf/eark-cits-3dpm.pdf"
+
+echo " - Finished"

--- a/doc/pdf/PDF.md
+++ b/doc/pdf/PDF.md
@@ -1,0 +1,5 @@
+---
+!INCLUDE "../../metadata.yaml"
+---
+
+!INCLUDE "body.md"


### PR DESCRIPTION
- added `create_pdf.sh` bash script that:
  - copies the document images to the `doc/pdf/` directory;
  - generates LaTeX versions of the `preface.md` and `postface.md` files with Pandoc;
  - uses Pandoc to generate a PDF from the Markdown and LaTeX files; and
- added the `doc/pdf/PDF.md` file to tie together the metadata with body.