### PR TITLE
FIX: Publication issues

### DIFF
--- a/create_site.sh
+++ b/create_site.sh
@@ -13,7 +13,7 @@ cp -rf profile examples specification/figs schema site/
 
 echo " - Generating main site specification and PDF markdown..."
 mvn clean package -f spec-publisher/pom.xml
-java -jar ./spec-publisher/target/mets-profile-processor-0.1.0-SNAPSHOT.jar -f ./specification.yaml -o doc/site profile/E-ARK-3DPM-ROOT_v1.0.0.xml profile/E-ARK-3DPM-REPRESENTATION_v1.0.0.xml 
+java -jar ./spec-publisher/target/mets-profile-processor-0.2.0-SNAPSHOT.jar -f ./specification.yaml -o doc/site profile/E-ARK-3DPM-ROOT_v1.0.0.xml profile/E-ARK-3DPM-REPRESENTATION_v1.0.0.xml 
 
 echo " - MARKDOWN-PP: generating site page with TOC..."
 cd doc/site || exit

--- a/profile/E-ARK-3DPM-REPRESENTATION_v1.0.0.xml
+++ b/profile/E-ARK-3DPM-REPRESENTATION_v1.0.0.xml
@@ -78,7 +78,7 @@
           </dl>
         </description>
       </requirement>
-      <requirement ID="3DPM34" REQLEVEL="MUST" RELATEDMAT="VocabularyContentCategory" EXAMPLES="metsRepElementExample">
+      <requirement ID="3DPM34" REQLEVEL="MUST" RELATEDMAT="VocabularyContentCategory" EXAMPLES="metsRepRootElementExample">
         <description>
           <head>Content Category</head>
           <p>The `mets/@TYPE` attribute is set to the value "OTHER".</p>
@@ -94,7 +94,7 @@
           </dl>
         </description>
       </requirement>
-      <requirement ID="3DPM35" REQLEVEL="MUST" RELATEDMAT="VocabularyContentCategory Vocabulary3DPM" EXAMPLES="metsRepElementExample">
+      <requirement ID="3DPM35" REQLEVEL="MUST" RELATEDMAT="VocabularyContentCategory Vocabulary3DPM" EXAMPLES="metsRepRootElementExample">
         <description>
           <head>Other Content Category</head>
           <p>The `mets/@csip:OTHERTYPE` attribute is set to the value "Product Model Data".</p>
@@ -110,7 +110,7 @@
           </dl>
         </description>
       </requirement>
-      <requirement ID="3DPM36" REQLEVEL="MUST" RELATEDMAT="VocabularyContentInformationTypeSpecification" EXAMPLES="metsRepElementExample">
+      <requirement ID="3DPM36" REQLEVEL="MUST" RELATEDMAT="VocabularyContentInformationTypeSpecification" EXAMPLES="metsRepRootElementExample">
         <description>
           <head>Content information type specification</head>
           <p>The `mets/@csip:CONTENTINFORMATIONTYPE` attribute is set to  the value "cits3dpm_v1_0"</p>
@@ -126,7 +126,7 @@
           </dl>
         </description>
       </requirement>
-      <requirement ID="3DPM37" REQLEVEL="MUST" EXAMPLES="metsRepElementExample">
+      <requirement ID="3DPM37" REQLEVEL="MUST" EXAMPLES="metsRepRootElementExample">
         <description>
           <head>METS Profile</head>
           <p>The value is set to "https://cits3dpm.dilcis.eu/profile/E-ARK-3dpm-REPRESENTATION-v1-0-0.xml".</p>

--- a/profile/E-ARK-3DPM-ROOT_v1.0.0.xml
+++ b/profile/E-ARK-3DPM-ROOT_v1.0.0.xml
@@ -489,7 +489,7 @@
       PROFILE="https://cits3dpm.dilcis.eu/profile/E-ARK-3dpm-ROOT-v1-0-0.xml">
     </mets:mets>
   </Example>
-  <Example ID="metsHdrElementExample" LABEL="METS example of root METS Header with submission agreements for an eHealth1 IP.">
+  <Example ID="metsRootHdrElementExample" LABEL="METS example of root METS Header with submission agreements for an eHealth1 IP.">
     <mets:metsHdr CREATEDATE="2024-04-24T14:37:49.602+01:00"
         LASTMODDATE="2024-04-24T14:37:49.602+01:00"
         RECORDSTATUS="NEW"
@@ -575,7 +575,7 @@
       </mets:fileGrp>
     </mets:fileSec>
   </Example>
-  <Example ID="struct-map-example" LABEL="METS root example of the mandatory structural map including representations for eHealth1">
+  <Example ID="structMapExample" LABEL="METS root example of the mandatory structural map including representations for eHealth1">
     <mets:structMap ID="struct-map-example" TYPE="PHYSICAL" LABEL="CSIP" xmlns:mets="http://www.loc.gov/METS/">
       <mets:div ID="struct-map-example-div" LABEL="cits-3dpm-example">
         <mets:div ID="struct-map-metadata-div" LABEL="Metadata" DMDID="dmd-ead-file" ADMD="digiprov-premis-file1 rights-premis-file1 rights-premis-file1" />

--- a/specification.yaml
+++ b/specification.yaml
@@ -143,6 +143,10 @@ body:
     type: file
     source: specification/implementation/premis.md
 
+  - name: glossary
+    type: file
+    source: specification/glossary/glossary.md
+
 appendices:
   - name: mets.examples
     heading: "CITS3D Information Package METS Examples"

--- a/specification/implementation/implementation.md
+++ b/specification/implementation/implementation.md
@@ -1,12 +1,11 @@
 # Implementation
 
-<a name="Section4.1"><a/>
-
 ## Package Structure
 
 The CITS 3D Product Model information structure inherits its package structure from the E-ARK Common Specification for Information Packages and is shown in [Figure 4](#fig4). It can be seen that additional folders have been added for authentication documentation at root and representation level but otherwise the structure is identical. 
 
 <a name="fig4"></a>
+
 ![Example Information Package Folder Structure](figs/fig_4_package_structure.svg "Example Information Package Folder Structure")
 
 **Figure 4:** Example Information Package Folder Structure
@@ -33,11 +32,7 @@ Specific requirements for the CITS 3D Product Model folder structure are as foll
 
 **3DPM3**: the Documentation folder at package and representation level SHOULD include a sub-folder named Other. This is an extension of CSIPSTR16.
 
-<a name="Section4.2"><a/>
-
 ## Metadata and Supporting Information
-
-<a name="Section4.2.1"><a/>
 
 ### Descriptive Metadata
 
@@ -46,8 +41,6 @@ According to LOTAR: “The producer creates a set of Descriptive Information (DI
 Neither CSIP or LOTAR prescribe specific schemas for descriptive information and so this is left to be determined by the user organisation. According to CSIP this should be according to a standardised schema such as for example EAD, Dublin Core, MODS or a locally defined schema that must be included in the package. 
 
 It is assumed that it would also be desirable that Validation information, i.e. Validation Properties rules data is also referenced. This specification does not specify where this information should be located in any respective standardised descriptive metadata schema and this will be an organisational decision. LOTAR does however prescribe that the location of information references in SIPs be stated in a Submission Agreement. This specification also recommends that Verification and Validation supporting documentation as described below is included in the package and that Verification and Validation events are recorded within PREMIS.  
-
-<a name="Section4.2.2"><a/>
 
 ### Authentication
 
@@ -74,9 +67,7 @@ Good archival practice states that we should not only include the reference to V
   
 This specification does not detail the content or format of Validation and Verification information which may be specified within other standards such as LOTAR.
 
-<a name="Section4.2.3"><a/>
-
-### Digital Signatures
+#### Digital Signatures
 
 A Digital Signature is a defined method to sign an object in electronic environments; it provides means to authenticate the signatory and the signed object in an unambiguous and safe way by attaching to or logically associating data in digital form to other digital objects. In LOTAR it is defined by an encrypted hash code with additional information such as time of creation and owner of the signature. 
 
@@ -86,9 +77,7 @@ LOTAR requires that a Digital Signature is provided on Ingest, i.e. production o
 
 This specification recommends that any Digital Signature information be recorded within PREMIS [Section 2](specification/specification.md). PREMIS also requires that the operations to be performed for validating a Digital Signature are known. This can be by means of a canonicalized method, or if by a local method either documentation or a persistent link to archived documentation or a resource must be provided.
 
-**3DPM9:** If Digital Signatures are provided then documentation MUST be included in the documentation/authentication folder or a persistent link provided to a resource. 
-
-<a name="Section4.2.4"><a/>
+**3DPM9:** If Digital Signatures are provided then documentation MUST be included in the documentation/authentication folder or a persistent link provided to a resource.
 
 ### Preservation Metadata
 
@@ -110,9 +99,8 @@ It is recommended that users review the Common Specification for Preservation Me
 
 **3DPM10:** there SHOULD be a PREMIS file produced according to the CSPM and the requirements of this CITS in the representation/metadata/preservation folder of each Representation of the Information Package.
 
-<a name="Section4.2.5"><a/>
-
 ### Rights Metadata
-From the principle above detailed Rights information should be recorded within PREMIS and as such a PREMIS file should be included at package level to contain this. 
+
+From the principle above detailed Rights information should be recorded within PREMIS and as such a PREMIS file should be included at package level to contain this.
 
 **3DPM11:** there SHOULD be a PREMIS file produced according to the CSPM and the requirements of this CITS in the metadata/preservation folder of the Information Package containing Rights information.

--- a/specification/implementation/mets.md
+++ b/specification/implementation/mets.md
@@ -1,14 +1,13 @@
+### METS
 
-<a name="Section4.3"><a/>
-
-## Use of METS in CITS 3D PM
+#### Use of METS in CITS 3D PM
 
 CSIP specifies that METS files be located at the root of the package folder structure (Root METS) and optionally in each of the Representations within its respective root folder (Representation METS). The CITS 3D PM has a requirement to contain at least one Representation and so will contain at minimum a root METS and a Representation METS file. 
 
-### Root METS File
+#### Root METS File
 
 The root METS file must adhere to the requirements of the CSIP and Information Package specifications. In addition, there are specific requirements for CITS 3D PM and in some cases, the level of the CSIP or package requirements have been increased (but never decreased).
 
-### Root METS root element
+#### Root METS root element
 
 CITS 3D PM does not change or extend any of the requirements for the Root METS root element. Information is given in the tables regarding the specific content type attributes to be used in CITS 3D PM.

--- a/specification/implementation/metsdmdsec.md
+++ b/specification/implementation/metsdmdsec.md
@@ -1,10 +1,10 @@
-### Root METS descriptive metadata section (element dmdSec)
+#### Root METS descriptive metadata section (element dmdSec)
 
 According to LOTAR: “the producer creates a set of Descriptive Information (DI), which includes archive metadata meeting the archives requirements (according to ISO 14721:2003 – OAIS).” Neither  CSIP or LOTAR make any assumptions regarding the use of specific descriptive metadata schemas and so this is left to the user organisation with a recommendation to use standardised or defined schemas.
 
 There are no specific requirements in CITS 3D PM for the root METS descriptive metadata section.
 
-### Root METS administrative metadata section (element amdSec)
+#### Root METS administrative metadata section (element amdSec)
 
 The administrative metadata section contains four sub-sections each used to record different types of metadata for package content: technical metadata (element techMD) records technical metadata; rights metadata (element rightsMD) records intellectual property rights information; source metadata (element sourceMD) records descriptive technical or rights metadata for an analogue source for a digital object; and digital provenance metadata (element digiprovMD) records digital preservation information, e.g. audit information for an object’s lifecycle.
 
@@ -12,6 +12,6 @@ The CSIP (and METS) categorise preservation metadata as administrative metadata,
 
 As detailed Rights information is required by LOTAR for the package then CITS 3D PM recommends the inclusion of a PREMIS file in the metadata/preservation folder containing detailed Rights information as described in [Section 4.5.3](#Section4.5.3) and any digital provenance metadata as described in the CITS Preservation Metadata.
 
-### Root METS file metadata section (element fileSec)
+#### Root METS file metadata section (element fileSec)
 
 The CSIP does not make use of the METS fileSec element mandatory, but it is strongly recommended. In the 3D PM CITS the use of the METS fileSec element at the package level becomes mandatory, such as to reference the METS files within each representation.

--- a/specification/implementation/metshead.md
+++ b/specification/implementation/metshead.md
@@ -1,3 +1,3 @@
-### Root METS header element (element metsHdr)
+#### Root METS header element (element metsHdr)
 
 The tables describe the differences in the package metsHdr element between CSIP, IP and the CITS 3D PM specification.

--- a/specification/implementation/metsstructmap.md
+++ b/specification/implementation/metsstructmap.md
@@ -1,4 +1,4 @@
-### Root METS structural map (element structMap)
+#### Root METS structural map (element structMap)
 
 The METS structural map element is the only mandatory element in the METS specification. It provides an overview of the components described in the METS document. It can also link the elements in the structure to associated content files and metadata. In CITS 3D PM the package structMap describes the high-level structure of all the content in the package and links to at least one Representation. To allow for the inclusion of multiple Product Model Representations in each package, the CITS 3D PM specification requires that each Product Model has a discrete div element.
 

--- a/specification/implementation/premis.md
+++ b/specification/implementation/premis.md
@@ -1,11 +1,7 @@
 
-<a name="Section4.5"><a/>
+### PREMIS
 
-## PREMIS
-
-<a name="Section4.5.1"><a/>
-
-### Use of PREMIS in CITS 3D PM
+#### Use of PREMIS in CITS 3D PM
 
 The use of PREMIS within the 3D PM CITS must follow the requirements of the CITS PREMIS which can be found at: (<https://dilcis.eu/content-types/cits-premis>).
 
@@ -19,15 +15,11 @@ For 3D PM CITS the use of PREMIS follows an interpretation of LOTAR as described
 
 Following CITS PREMIS the CITS 3D PM follows the requirements and recommendation of the PREMIS Data Dictionary which can be found at: (<https://www.loc.gov/standards/premis/v3/premis-3-0-final.pdf>).
 
-<a name="Section4.5.2"><a/>
-
-### Attribute values and controlled vocabularies
+#### Attribute values and controlled vocabularies
 
 Use of controlled vocabularies for the values of semantic units is encouraged within the PREMIS Data Dictionary and through best practice. Specific controlled vocabularies for semantic units are not provided by the CITS but their use is encouraged, particularly the use of any vocabularies provided by the LOTAR standard. If local vocabularies are used within the repository then these should be included within each package.
 
-<a name="Section4.5.3"><a/>
-
-### Use of PREMIS at package level
+#### Use of PREMIS at package level
 
 PREMIS can be used in addition to METS to support compliance with LOTAR in recording  specific rights information at package level. Note that if PREMIS is used then the requirements of the CITS Preservation apply and those provided by the CITS 3D PM are in addition to these.
 
@@ -39,9 +31,7 @@ PREMIS can be used in addition to METS to support compliance with LOTAR in recor
 
 **3D PM53:** Rights for the entire package (e.g. copyright, license, statute, other, rights grants) MAY be recorded within the PREMIS file located in the metadata/preservation folder using the PREMIS Rights entity and must follow the guidelines set out in CITS PREMIS. Each individual rights statement (copyright, licence, statute, other, rights granted) must be held in a separate rightsStatement semantic unit. Designation of the basis for the right or permission can be taken from the vocabulary available at: <http://id.loc.gov/vocabulary/preservation/rightsBasis.html> which are: license, copyright, statute, other. Information on rights associated with the rights basis can be included within the otherRightsInformation PREMIS semantic unit container using values from available controlled vocabularies.
 
-<a name="Section4.5.4"><a/>
-
-### Use of PREMIS at Representation level
+#### Use of PREMIS at Representation level
 
 PREMIS can be used in addition to METS to support compliance with LOTAR in recording  specific Validation and Verification events information at representation level. Note that if PREMIS is used then the requirements of the CITS Preservation apply and those provided by the CITS 3D PM are in addition to these.
 

--- a/specification/implementation/repmetsfiles.md
+++ b/specification/implementation/repmetsfiles.md
@@ -1,7 +1,7 @@
-## Representation METS Files
+#### Representation METS Files
 
 The Representation METS files are used to describe the data structure as included in the data folder of each Representation (Product Model representations) via the structMap element and to reference additional descriptive and preservation metadata.
 
-### Representation METS root element
+#### Representation METS root element
 
 CITS 3D PM does not change or extend any of the requirements for the Representation root element but particular notice is drawn to the specific requirements of a Representation METS root element and the specific content type attributes to be used in CITS 3D PM.

--- a/specification/implementation/repmetsfilesec.md
+++ b/specification/implementation/repmetsfilesec.md
@@ -1,3 +1,3 @@
-### Representation METS file metadata section (element fileSec)
+#### Representation METS file metadata section (element fileSec)
 
 The CSIP does not make the use of the METS fileSec element mandatory, but it is strongly recommended. In the 3D Product Model CITS, the use of the METS fileSec element at the Representation level becomes mandatory, such as to reference the Content Data Objects within each Representation and link to preservation information held within mandatory PREMIS files.

--- a/specification/implementation/repmetsheader.md
+++ b/specification/implementation/repmetsheader.md
@@ -1,12 +1,12 @@
-### Representation METS header element (element metsHdr)
+#### Representation METS header element (element metsHdr)
 
 There are no specific requirements for the header element in a CITS 3D PM Representation METS. The 3D PM Representation metsHdr element should comply with the metsHdr requirements in the appropriate Information Package profile and can be used to identify specific agents related to a Product Model Representation.
 
-### Representation METS descriptive metadata section (element dmdSec)
+#### Representation METS descriptive metadata section (element dmdSec)
 
 There are no specific requirements in CITS 3D PM for the Representation METS Descriptive Metadata section.
 
-### Representation METS administrative metadata section (element amdSec)
+#### Representation METS administrative metadata section (element amdSec)
 
 The Administrative Metadata section contains four sub-sections each used to record different types of metadata for package content: technical metadata (element techMD) records technical metadata; rights metadata (element rightsMD) records intellectual property rights information;  source metadata (element sourceMD) records descriptive technical or rights metadata for an analogue source for a digital object; and digital provenance metadata (element digiprovMD) records digital preservation information, e.g. audit information for an object’s lifecycle.
 

--- a/specification/implementation/repmetsstructmap.md
+++ b/specification/implementation/repmetsstructmap.md
@@ -1,3 +1,3 @@
-### Representation METS structural map (element structMap)
+#### Representation METS structural map (element structMap)
 
 The METS structural map element is the only mandatory element in the METS specification and is hence mandatory within the Representation METS. There must be one structural map present in each Representation METS file following the requirements of the CSIP. As Authentication documentation SHOULD be included in each Representation within 3D PM CITS, there is also a mandatory requirement for a structMap division for the documentation/authentication folder. The specific requirements for elements, sub-elements and attributes for 3D PM CITS, which differ from the CSIP, are listed in the table. 


### PR DESCRIPTION
- fixed the bad example ids in `profile/E-ARK-3DPM-REPRESENTATION_v1.0.0.xml`;
- fixed heading levels in the specification document;
- added missing glossary entry to `specification.yaml`;
- updated `spec-publisher` for fixes to examples, PDF generation and site TOC generation; and
- updated `create_site.sh` to use the latest `spec-publisher` version.